### PR TITLE
Telling operator to set the host group

### DIFF
--- a/release-tracking/assets/scripts/dynakube.yaml
+++ b/release-tracking/assets/scripts/dynakube.yaml
@@ -127,7 +127,8 @@ spec:
       # Available options: https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
       # Limitations: https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
       #
-      # args: []
+      args:
+        - "--set-host-group=at-demo-release"
       
 
   # Configuration for ActiveGate instances.


### PR DESCRIPTION
This is required to ensure that the related process group instances get the tag based off the process group.

Without this the operator does not install with any host group and so the tags are not set, and events do not make it to the related entities.