### PR TITLE
add build set to docker compose up

### DIFF
--- a/new/assets/scripts/intro_foreground.sh
+++ b/new/assets/scripts/intro_foreground.sh
@@ -24,7 +24,7 @@ cp .env.example .env
 ###################################################################
 # Step [3/3]: Start things up!
 ###################################################################
-docker compose up --detach
+docker compose up --build --detach
 
 # ---------------------------------------------#
 #       🎉 Installation Complete 🎉           #


### PR DESCRIPTION
The client-side changes haven't been pushed to GHCR yet. This PR adds the build flag so the container is built as part of the docker compose startup process.